### PR TITLE
initialize rt with undefined instead of null

### DIFF
--- a/jsPsych_version/js/custom-stop-signal-plugin.js
+++ b/jsPsych_version/js/custom-stop-signal-plugin.js
@@ -99,7 +99,7 @@ jsPsych.plugins["custom-stop-signal-plugin"] = (function() {
 
     // store response
     var response = {
-      rt: null,
+      rt: undefined,
       key: null
     };
 


### PR DESCRIPTION
null is evaluated as 0, so when there was no response the trial returns a (negative) number as an rt. 

Changing it to undefined would return a nan to a non-response trial, making it easier to identify.